### PR TITLE
Add arkworks asm optimization to asm feature

### DIFF
--- a/plain_implementations/Cargo.toml
+++ b/plain_implementations/Cargo.toml
@@ -33,7 +33,7 @@ criterion = "0.4"
 
 [features]
 default = []
-asm = ["sha2/asm", "blake2/simd_asm"]
+asm = ["sha2/asm", "blake2/simd_asm", "ark-ff/asm"]
 
 [[bench]]
 name = "mt_bls12"


### PR DESCRIPTION
This PR adds the [asm feature](https://github.com/arkworks-rs/algebra#assembly-backend-for-field-arithmetic) of arkworks to the asm feature of the crate. This feature enables assembly optimizations for field arithmetic operations.