### PR TITLE
Consider only subsets, not permutations

### DIFF
--- a/poseidon2_rust_params.sage
+++ b/poseidon2_rust_params.sage
@@ -461,7 +461,7 @@ def generate_matrix_partial_small_entries(FIELD, FIELD_SIZE, NUM_CELLS):
         exit(1)
     elif FIELD == 1:
         M_circulant = matrix.circulant(vector([F(0)] + [F(1) for _ in range(0, NUM_CELLS - 1)]))
-        combinations = list(itertools.product(range(2, 6), repeat=NUM_CELLS))
+        combinations = itertools.combinations(range(2, 6), NUM_CELLS)
         for entry in combinations:
             M = M_circulant + matrix.diagonal(vector(F, list(entry)))
             print(M)


### PR DESCRIPTION
Empirically (in large fields), if a solution is satisfying then so are all its permutation and no valid solution has repeated elements. So it is sufficient to iterate over all subsets of length `NUM_CELLS` of the small range, which is much faster for larger sizes.

Additionally, the iterator is not converted to a list (which leads to a combinatorial sized memory allocation).

Note that the range is left hardcoded and will have to be increased for larger `NUM_CELLS`.